### PR TITLE
Use multistage builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
-FROM gcc:latest
+FROM alpine AS build_gcc
 WORKDIR /tmp/myapp
 COPY ./src/helloworld.cpp /tmp/myapp
-RUN gcc -o helloworld helloworld.cpp
-CMD ["./helloworld"]
+RUN apk add gcc build-base && gcc -o helloworld helloworld.cpp
+FROM alpine:latest
+WORKDIR /app
+COPY --from=build_gcc /tmp/myapp/ .
+ENTRYPOINT ["./helloworld"]


### PR DESCRIPTION
Using multistage build reduces image sice. This makes it easier to set up the general demonstrator.